### PR TITLE
Fix for spaces in file paths

### DIFF
--- a/lib/atom-scalariform.js
+++ b/lib/atom-scalariform.js
@@ -39,9 +39,9 @@ module.exports = {
     } else {
       fileToFormatPath = activeTextEditor.getPath();
       execution = exec(
-        javaPath + ' -jar ' + scalariformJarPath + ' -p=' + atom.config.get(
+        javaPath + ' -jar ' + scalariformJarPath + ' -p="' + atom.config.get(
           'scalariform.propertiesFile'
-        ) + ' ' + fileToFormatPath,
+        ) + '" "' + fileToFormatPath + '"',
         function(error, stdout, stderr) {
           if (error) {
             atom.notifications.addError("Unable to format file: " + error);


### PR DESCRIPTION
This patch fixes an issue where the tool would not work if the preferences file or the current .scala file path contained spaces
