### PR TITLE
add support for ammonite scripts *.sc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # atom-scalariform package
 
-Allows formatting of scala files using scalariform.
+Allows formatting of scala files using scalariform. It also supports [Ammonite](https://github.com/lihaoyi/Ammonite) scripts.
 
 You can configure the properties file to be used in your atom config:
 ```
@@ -8,7 +8,7 @@ scalariform:
   propertiesFile: "/path/to/scalariform.properties"
 ```
 
-To format a .scala file, first save it then you can run the formatter by pressing:
+To format a .scala/.sc file, first save it then you can run the formatter by pressing:
 
 ```
 ctrl-shift-s

--- a/lib/atom-scalariform.js
+++ b/lib/atom-scalariform.js
@@ -33,7 +33,7 @@ module.exports = {
     var scalariformJarPath = packagePath() + '/deps/scalariform.jar';
 
     if (activeTextEditor === '' ||
-      !activeTextEditor.getPath().endsWith(".scala")) {
+      !(activeTextEditor.getPath().endsWith(".scala") || activeTextEditor.getPath().endsWith(".sc"))) {
       atom.notifications.addError(
         "You do not have a valid scala file open!");
     } else {


### PR DESCRIPTION
Li Haoyi's project [Ammonite](https://github.com/lihaoyi/Ammonite) allows to write Scala scripts without requiring to boot sbt.
Because of that it's not possible to use a Scala IDE and that makes Atom a good fit.

I've added support for considering `.sc` files as valid files for formatting.