### PR TITLE
scalariform props file absolute/relative path flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,26 @@
 # atom-scalariform package
 
-Allows formatting of scala files using scalariform. It also supports [Ammonite](https://github.com/lihaoyi/Ammonite) scripts.
+Allows formatting of [Scala](https://github.com/scala/scala) files using [scalariform](https://github.com/scala-ide/scalariform). It also supports [Ammonite](https://github.com/lihaoyi/Ammonite) scripts.
 
-You can configure the properties file to be used in your atom config:
+You can configure the `scalariform` properties file to be used in your Atom config:
 ```
 scalariform:
   propertiesFile: "/path/to/scalariform.properties"
 ```
 
+If `propertiesFile` starts with `/` it is considered an absolute path, otherwise the `propertiesFile` path is considered relative to the about-to-format file's project folder.
+
+## Relative properties file path
+Assuming:
+* the file to format is located at `/home/user/myProjects/myProject/src/main/scala/com/user/Test.scala`
+* the Atom project folder is `myProject`
+* and `propertiesFile` is defined as `scalariform.properties`
+
+the `scalariform` properties file will be loaded from `/home/user/myProjects/myProject/scalariform.properties`.
+
+If a project folder cannot be found, the plugin will try to load the `propertiesFile` as an absolute path.
+
+## Usage
 To format a .scala/.sc file, first save it then you can run the formatter by pressing:
 
 ```

--- a/lib/atom-scalariform.js
+++ b/lib/atom-scalariform.js
@@ -5,6 +5,18 @@ var packagePath = function() {
   return atom.packages.getLoadedPackage('atom-scalariform').path;
 }
 
+var projectPath = function(fileToFormatPath) {
+  var ref = atom.project.getDirectories();
+  for (var i = 0, len = ref.length; i < len; i++) {
+    var directory = ref[i];
+    if (fileToFormatPath.indexOf(directory.path) === 0) {
+            return directory.path + '/';
+      }
+  }
+
+  return '';
+}
+
 module.exports = {
 
   activate: function() {
@@ -29,6 +41,8 @@ module.exports = {
     'use strict';
     var execution;
     var fileToFormatPath;
+    var scalariformPropertiesFile;
+    var scalariformPropertiesFilePath;
     var activeTextEditor = atom.workspace.getActiveTextEditor();
     var scalariformJarPath = packagePath() + '/deps/scalariform.jar';
 
@@ -38,10 +52,12 @@ module.exports = {
         "You do not have a valid scala file open!");
     } else {
       fileToFormatPath = activeTextEditor.getPath();
+      scalariformPropertiesFile = atom.config.get('scalariform.propertiesFile')
+      scalariformPropertiesFilePath = scalariformPropertiesFile && scalariformPropertiesFile.startsWith("/") ? '' : projectPath(fileToFormatPath);
+
       execution = exec(
-        javaPath + ' -jar ' + scalariformJarPath + ' -p="' + atom.config.get(
-          'scalariform.propertiesFile'
-        ) + '" "' + fileToFormatPath + '"',
+        javaPath + ' -jar ' + scalariformJarPath + ' -p="' +
+        scalariformPropertiesFilePath + scalariformPropertiesFile + '" "' + fileToFormatPath + '"',
         function(error, stdout, stderr) {
           if (error) {
             atom.notifications.addError("Unable to format file: " + error);


### PR DESCRIPTION
Scalariform properties files are usually project dependent and I think atom-scalariform could support it by having a absolute/relative flag regarding the properties file path.

I've created a new property `relativeToProject` which, if set to true, assumes the `propertiesFile` path is relative to the about-to-format file's project folder.